### PR TITLE
Add configuration to disable external diff-engine

### DIFF
--- a/src/dotnet/ReSharperPlugin.Verify/VerifyConfiguration.cs
+++ b/src/dotnet/ReSharperPlugin.Verify/VerifyConfiguration.cs
@@ -1,0 +1,17 @@
+using System;
+using JetBrains.Application;
+
+namespace ReSharperPlugin.Verify
+{
+    [ShellComponent]
+    public class VerifyConfiguration
+    {
+        public VerifyConfiguration()
+        {
+            Environment.SetEnvironmentVariable(
+                "DiffEngine_Disabled",
+                bool.TrueString,
+                EnvironmentVariableTarget.Process);
+        }
+    }
+}


### PR DESCRIPTION
I think it would make sense to set the `DiffEngine_Disabled` environment variable to disable the diff engine from being opened automatically. This would preserve the configured behavior when executed from command-line or other IDEs. A similar setting might make sense for the clipboard, but afaik there is no environment variable for that yet.

Follow up from https://twitter.com/ursenzler/status/1422208628174565378