### PR TITLE
disable clipboard when plugin running

### DIFF
--- a/src/dotnet/ReSharperPlugin.Verify/VerifyConfiguration.cs
+++ b/src/dotnet/ReSharperPlugin.Verify/VerifyConfiguration.cs
@@ -1,0 +1,17 @@
+using System;
+using JetBrains.Application;
+
+namespace ReSharperPlugin.Verify
+{
+    [ShellComponent]
+    public class VerifyConfiguration
+    {
+        public VerifyConfiguration()
+        {
+            Environment.SetEnvironmentVariable(
+                "Verify_DisableClipboard",
+                bool.TrueString,
+                EnvironmentVariableTarget.Process);
+        }
+    }
+}


### PR DESCRIPTION
While the plugin should not change the diff tool behavior, it should disable the clipboard behavior of verify. The reason is that, with the plugin running, it then acts as the default mechanism for accepting snapshot changes. this is consistent with the behavior of DiffEngineTray