### PR TITLE
Throw Exception When Launching Diff Fails

### DIFF
--- a/src/dotnet/ReSharperPlugin.Verify.Tests/VerifyCompareActionTest.cs
+++ b/src/dotnet/ReSharperPlugin.Verify.Tests/VerifyCompareActionTest.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using DiffEngine;
+using NUnit.Framework;
+
+namespace ReSharperPlugin.Verify.Tests;
+
+[TestFixture]
+public class VerifyCompareActionTest
+{
+    static object[] AllDefinedLaunchResultValues =
+        GetAllEnumValuesOf<LaunchResult>()
+            .Select(e => new object[] { e })
+            .ToArray();
+    
+    [TestCaseSource(nameof(AllDefinedLaunchResultValues))]
+    public void IsError_WhenDefinedResultEnum_ShouldNotThrow(LaunchResult launchResult)
+    {
+        // Note: When this test fails you will have to adapt the implementation
+        // to either consider the new enum value as success or error.
+        VerifyCompareAction.IsError(launchResult);
+    }
+
+    static TEnum[] GetAllEnumValuesOf<TEnum>()
+        where TEnum: Enum
+        => (TEnum[])Enum.GetValues(typeof(TEnum));
+}


### PR DESCRIPTION
`DiffRunner.Launch` returns an error when it fails to actually show the diff, but this error is currently being swallowed.
With this PR I attempt to remedy this:

Results `DiffRunner.Launch` are recorded, classified as either error or success, and an exception is thrown if any launch attempt fails. The error message contains the file path and result (enum value name).

I suspect there may be a better way to report such errors to ReSharper/Rider, but I'm completely unfamiliar with ReSharper/Rider plugin development. So maybe @matkoch could improve on this PR?