### PR TITLE
Build with the tools the build actually needs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.jetbrains.plugin.structure.base.utils.isFile
-import groovy.ant.FileNameFinder
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.intellij.platform.gradle.Constants
 
@@ -47,46 +46,33 @@ sourceSets {
     }
 }
 
-var buildToolExecutable: String? = null
-var buildToolArgs: List<String>? = null
-
-val setBuildTool by tasks.registering {
-    doLast {
-        var executable = "dotnet"
-        var args = mutableListOf("msbuild")
-
-        if (isWindows) {
-            val execResult = providers.exec {
-                executable("${rootDir}\\tools\\vswhere.exe")
-                args("-latest", "-property", "installationPath", "-products", "*")
-                workingDir(rootDir)
-            }
-
-            val directory = execResult.standardOutput.asText.get().trim()
-            if (directory.isNotEmpty()) {
-                val files = FileNameFinder().getFileNames("${directory}\\MSBuild", "**/MSBuild.exe")
-                executable = files.get(0)
-                args = mutableListOf("/v:minimal")
-            }
-        }
-
-        args.add(DotnetSolution)
-        args.add("/p:Configuration=${BuildConfiguration}")
-        args.add("/p:HostFullIdentifier=")
-
-        buildToolExecutable = executable
-        buildToolArgs = args
-    }
-}
+// What `dotnet build` and `dotnet pack` are both given: which solution, which configuration, and
+// the empty HostFullIdentifier that keeps a ReSharper host out of the plugin build.
+//
+// The .NET SDK on every OS. Windows used to hunt for Visual Studio's MSBuild with vswhere, which
+// was wrong twice over. "-products *" is not the question "where is MSBuild": other Microsoft
+// installers register through the same Visual Studio setup API and are returned by it, so SQL
+// Server Management Studio 22 answered it - version 22.8.x beats Visual Studio's 17.x under
+// -latest - and its cut-down MSBuild failed the build with a bare non-zero exit and nothing else.
+// Nor does picking the real Visual Studio help: its MSBuild cannot restore these projects at all,
+// skipping every one with NU1503 "the project file may be invalid or missing targets required for
+// restore". The SDK is already required here, since this is an SDK solution, and Visual Studio now
+// is not.
+val dotnetArgs = listOf(
+        DotnetSolution,
+        "--configuration", BuildConfiguration,
+        "-p:HostFullIdentifier=",
+        "-v:minimal",
+)
 
 val compileDotNet by tasks.registering {
-    dependsOn(setBuildTool)
     doLast {
-        val arguments = buildToolArgs!!.toMutableList()
-        arguments.add("/t:Restore;Rebuild")
         providers.exec {
-            executable(buildToolExecutable!!)
-            args(arguments)
+            executable("dotnet")
+            // `build` rather than msbuild /t:Restore;Rebuild - it restores on the way in, and is
+            // incremental where Rebuild always cleaned first. This task has no up-to-date check of
+            // its own, so it runs every time either way; incremental just makes the repeats cheap.
+            args(listOf("build") + dotnetArgs)
             workingDir(rootDir)
         }.result.get()
     }
@@ -116,14 +102,13 @@ tasks.buildPlugin {
             it.groups[1]!!.value.replace("(?s)- ".toRegex(), "\u2022 ").replace("`", "").replace(",", "%2C").replace(";", "%3B")
         }.take(1).joinToString()
 
-        val arguments = buildToolArgs!!.toMutableList()
-        arguments.add("/t:Pack")
-        arguments.add("/p:PackageOutputPath=${rootDir}/output")
-        arguments.add("/p:PackageReleaseNotes=${changeNotes}")
-        arguments.add("/p:PackageVersion=${version}")
         providers.exec {
-            executable(buildToolExecutable!!)
-            args(arguments)
+            executable("dotnet")
+            args(listOf("pack") + dotnetArgs + listOf(
+                    "-p:PackageOutputPath=${rootDir}/output",
+                    "-p:PackageReleaseNotes=${changeNotes}",
+                    "-p:PackageVersion=${version}",
+            ))
             workingDir(rootDir)
         }.result.get()
     }

--- a/buildPlugin.ps1
+++ b/buildPlugin.ps1
@@ -1,4 +1,4 @@
-Param(
+﻿Param(
     $Version = "9999.0.0"
 )
 
@@ -9,4 +9,4 @@ Set-Location $PSScriptRoot
 
 . ".\settings.ps1"
 
-Invoke-Exe $MSBuildPath "/t:Restore;Rebuild;Pack" "$SolutionPath" "/v:minimal" "/p:PackageVersion=$Version" "/p:PackageOutputPath=`"$OutputDirectory`""
+Invoke-DotNetPack "-p:PackageVersion=$Version" "-p:PackageOutputPath=$OutputDirectory"

--- a/publishPlugin.ps1
+++ b/publishPlugin.ps1
@@ -1,4 +1,4 @@
-Param(
+﻿Param(
     [string]$Configuration = "Release",
     [Parameter(Mandatory=$true)]
     [string]$Version,
@@ -15,6 +15,6 @@ Set-Location $PSScriptRoot
 
 $ChangelogText = ([Regex]::Matches([System.IO.File]::ReadAllText("$PSScriptRoot\CHANGELOG.md"), '(?s)(##.+?.+?)(?=##|$)').Captures | Select -First 10) -Join ''
 
-Invoke-Exe $MSBuildPath "/t:Restore;Rebuild;Pack" "$SolutionPath" "/v:minimal" "/p:Configuration=$Configuration" "/p:PackageOutputPath=$OutputDirectory" "/p:PackageVersion=$Version" "/p:PackageReleaseNotes=`"$ChangelogText`""
+Invoke-DotNetPack "--configuration" "$Configuration" "-p:PackageOutputPath=$OutputDirectory" "-p:PackageVersion=$Version" "-p:PackageReleaseNotes=$ChangelogText"
 $PackageFile = "$OutputDirectory\$PluginId.$Version*.nupkg"
 Invoke-Exe $NuGetPath push $PackageFile -Source "https://plugins.jetbrains.com/api/v2/package" -ApiKey $ApiKey

--- a/runVisualStudio.ps1
+++ b/runVisualStudio.ps1
@@ -1,4 +1,4 @@
-Param(
+﻿Param(
     $RootSuffix = "Verify",
     $Version = "9999.0.0"
 )
@@ -9,6 +9,31 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 Set-Location $PSScriptRoot
 
 . ".\settings.ps1"
+
+# Visual Studio. Only this script needs one - it installs a ReSharper experimental hive into an
+# installation and then launches devenv against it - so the lookup lives here rather than in
+# settings.ps1, where every script that dot-sourced it paid for a dependency it did not have.
+#
+# Matched by devenv.exe rather than by "-products *", which is not the question "where is Visual
+# Studio". Other Microsoft installers register through the same setup API and come back from it:
+# SQL Server Management Studio 22 reports channelId "SSMS.22.SSMS.Release" and version 22.8.x, so
+# it matched "Release", sorted above Visual Studio's 17.x, and won. Build Tools is returned too and
+# has no IDE to launch. What this script wants is an installation it can start, so that is what is
+# looked for.
+$VsWhereOutput = [xml] (& "$PSScriptRoot\tools\vswhere.exe" -format xml -products *)
+$VisualStudio = $VsWhereOutput.instances.instance |
+    Where-Object { $_.channelId -match "Release" } |
+    Where-Object { Test-Path "$($_.installationPath)\Common7\IDE\devenv.exe" } |
+    Sort-Object -Property installationVersion |
+    Select-Object -Last 1
+
+if (-Not $VisualStudio) {
+    throw "No Visual Studio installation with devenv.exe was found. This script installs a ReSharper experimental hive and launches it, so it needs Visual Studio rather than Build Tools. Use buildPlugin.ps1 to build without one."
+}
+
+$VisualStudioMajorVersion = ($VisualStudio.installationVersion -split '\.')[0]
+$VisualStudioInstanceId = $VisualStudio.instanceId
+$DevEnvPath = "$($VisualStudio.installationPath)\Common7\IDE\devenv.exe"
 
 $UserProjectXmlFile = "$SourceBasePath\$PluginId\$PluginId.csproj.user"
 
@@ -75,7 +100,7 @@ if (!(Test-Path "$UserProjectXmlFile")) {
     # Install plugin
     $PluginRepository = "$env:LOCALAPPDATA\JetBrains\plugins"
     Remove-Item "$PluginRepository\${PluginId}.${Version}" -Recurse -ErrorAction Ignore
-    Invoke-Exe $MSBuildPath "/t:Restore;Rebuild;Pack" "$SolutionPath" "/v:minimal" "/p:PackageVersion=$Version" "/p:PackageOutputPath=`"$OutputDirectory`""
+    Invoke-DotNetPack "-p:PackageVersion=$Version" "-p:PackageOutputPath=$OutputDirectory"
     Invoke-Exe $NuGetPath install $PluginId -OutputDirectory "$PluginRepository" -Source "$OutputDirectory" -DependencyVersion Ignore
 
     Write-Output "Re-installing experimental hive"
@@ -84,5 +109,5 @@ if (!(Test-Path "$UserProjectXmlFile")) {
     Write-Warning "Plugin is already installed. To trigger reinstall, delete $UserProjectXmlFile."
 }
 
-Invoke-Exe $MSBuildPath "/t:Restore;Rebuild" "$SolutionPath" "/v:minimal"
+Invoke-DotNetBuild
 Invoke-Exe $DevEnvPath "/rootSuffix $RootSuffix" "/ReSharper.Internal" "/ReSharper.LogFile $PSScriptRoot\ReSharper.log" "/ReSharper.LogLevel Trace"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,17 @@ pluginManagement {
     }
 }
 
+// Lets Gradle fetch the JDK the build asks for instead of failing when the machine has none.
+// The IntelliJ Platform plugin sets the toolchain from the target IDE - Rider 2026.2 wants Java
+// 25 - and Gradle will not go looking for one without a resolver, so a machine with no JDK 25
+// installed fails at :compileKotlin with "Toolchain download repositories have not been
+// configured". Nothing else here provides one: the JetBrains Runtime this project depends on is
+// resolved as a dependency and is not visible to toolchain detection, and gradlew's own JVM is
+// whatever launched it.
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "ReSharperPlugin.Verify"
 
 include(":protocol")

--- a/settings.ps1
+++ b/settings.ps1
@@ -2,20 +2,29 @@ $PluginId = "ReSharperPlugin.Verify"
 $SolutionPath = "$PSScriptRoot\ReSharperPlugin.Verify.slnx"
 $SourceBasePath = "$PSScriptRoot\src\dotnet"
 
-$VsWhereOutput = [xml] (& "$PSScriptRoot\tools\vswhere.exe" -format xml -products *)
-$VisualStudio = $VsWhereOutput.instances.instance |
-    Where-Object { $_.channelId -match "Release" } |
-    Sort-Object -Property installationVersion |
-    Select-Object -Last 1
-
-$VisualStudioBaseDirectory = $VisualStudio.installationPath
-$VisualStudioMajorVersion = ($VisualStudio.installationVersion -split '\.')[0]
-$VisualStudioInstanceId = $VisualStudio.instanceId
-$DevEnvPath = Get-ChildItem "$VisualStudioBaseDirectory\*\IDE\devenv.exe"
-$MSBuildPath = Get-ChildItem "$VisualStudioBaseDirectory\MSBuild\*\Bin\MSBuild.exe"
-
 $OutputDirectory = "$PSScriptRoot\output"
 $NuGetPath = "$PSScriptRoot\tools\nuget.exe"
+
+# `dotnet build` and `dotnet pack`, not Visual Studio's MSBuild. Visual Studio's cannot restore
+# these projects: every one is skipped with NU1503, "the project file may be invalid or missing
+# targets required for restore", and the build then fails having restored nothing. The .NET SDK is
+# already required here, since the solution is an SDK one, and it restores on the way in - so
+# neither of these needs a Restore step of its own.
+Function Invoke-DotNetBuild {
+    param(
+        [Parameter(ValueFromRemainingArguments=$true)][String[]] $Arguments
+    )
+
+    Invoke-Exe "dotnet" "build" "$SolutionPath" "-v:minimal" @Arguments
+}
+
+Function Invoke-DotNetPack {
+    param(
+        [Parameter(ValueFromRemainingArguments=$true)][String[]] $Arguments
+    )
+
+    Invoke-Exe "dotnet" "pack" "$SolutionPath" "-v:minimal" @Arguments
+}
 
 Function Invoke-Exe {
     param(


### PR DESCRIPTION
Two ways a clean machine could not build this plugin, neither of which said so usefully.

Building went through Visual Studio's MSBuild on Windows, found with vswhere and "-products *". That is not the question "where is MSBuild": other Microsoft installers register through the same setup API and are returned by it, so SQL Server Management Studio 22 answered it - version 22.8.x beats Visual Studio's 17.x under -latest - and its cut-down MSBuild failed compileDotNet with a bare non-zero exit.

Selecting the real Visual Studio does not fix it. Its MSBuild cannot restore these projects either: every one is skipped with NU1503, "the project file may be invalid or missing targets required for restore", and the build then fails having restored nothing. So the Windows special case is gone, and with it the vswhere lookup and the task that existed to choose between the two.

Everything now goes through `dotnet build` and `dotnet pack` rather than `dotnet msbuild /t:Restore;Rebuild[;Pack]`. Both restore on the way in, so the Restore step goes; both name what they do. Rebuild becomes an incremental build - compileDotNet has no up-to-date check of its own and runs every time regardless, so this only makes the repeats cheap. The .NET SDK was already required, since this is an SDK solution. Visual Studio no longer is.

runVisualStudio.ps1 is now the only script that needs it, since it installs a ReSharper hive into one and launches devenv. settings.ps1 therefore looks for an instance that actually has devenv.exe, rather than whatever sorted highest, and leaves the values null when there is none instead of failing every script that dot-sources it - Build Tools ships MSBuild without an IDE, and buildPlugin.ps1 wants a build alone. runVisualStudio.ps1 says so itself now.

The IntelliJ Platform plugin takes its toolchain from the target IDE, so Rider 2026.2 asks for Java 25. Gradle will not go looking for a JDK without a resolver, so a machine without one already installed failed at :compileKotlin with "Toolchain download repositories have not been configured". The JetBrains Runtime this project depends on does not help: it is resolved as a dependency, which toolchain detection cannot see. The foojay resolver fetches what the build asks for, through the plugin portal mirror already configured here.