### PR TITLE
Update verify deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ github.event.repository.name }}.CI.${{ github.ref_name }}.${{ github.run_number }}
+          name: ${{ github.event.repository.name }}.CI.${{ github.run_number }}
           path: output
 
   Test:

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,23 +1,23 @@
 [
   {
     "name": "DiffEngine",
-    "version": "11.3.0",
+    "version": "19.3.3",
     "url": "https://github.com/VerifyTests/DiffEngine",
     "license": "MIT",
-    "licenseUrl": "https://github.com/VerifyTests/DiffEngine/blob/11.3.0/license.txt"
+    "licenseUrl": "https://github.com/VerifyTests/DiffEngine/blob/19.3.3/license.txt"
   },
   {
     "name": "Verify.ExceptionParsing",
-    "version": "31.27.0",
+    "version": "31.28.0",
     "url": "https://github.com/VerifyTests/Verify",
     "license": "MIT",
-    "licenseUrl": "https://github.com/VerifyTests/Verify/blob/31.27.0/license.txt"
+    "licenseUrl": "https://github.com/VerifyTests/Verify/blob/31.28.0/license.txt"
   },
   {
     "name": "EmptyFiles",
-    "version": "4.4.0",
+    "version": "8.18.2",
     "url": "https://github.com/VerifyTests/EmptyFiles",
     "license": "MIT",
-    "licenseUrl": "https://github.com/VerifyTests/EmptyFiles/blob/4.4.0/license.txt"
+    "licenseUrl": "https://github.com/VerifyTests/EmptyFiles/blob/8.18.2/license.txt"
   }
 ]

--- a/src/dotnet/Directory.Build.props
+++ b/src/dotnet/Directory.Build.props
@@ -26,9 +26,9 @@
     <Reference Include="System.Xaml" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="DiffEngine" Version="17.0.1" PrivateAssets="all" />
-    <PackageReference Include="EmptyFiles" Version="8.17.1" PrivateAssets="all" />
-    <PackageReference Include="Verify.ExceptionParsing" Version="31.27.0" PrivateAssets="all" />
+    <PackageReference Include="DiffEngine" Version="19.3.3" PrivateAssets="all" />
+    <PackageReference Include="EmptyFiles" Version="8.18.2" PrivateAssets="all" />
+    <PackageReference Include="Verify.ExceptionParsing" Version="31.28.0" PrivateAssets="all" />
     <PackageReference Include="System.Management" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.6.3" PrivateAssets="all" />
     <PackageReference Include="System.CodeDom" Version="10.0.0" PrivateAssets="all" />

--- a/src/dotnet/ReSharperPlugin.Verify/ReSharperPlugin.Verify.csproj
+++ b/src/dotnet/ReSharperPlugin.Verify/ReSharperPlugin.Verify.csproj
@@ -27,7 +27,6 @@
     <Content Include="bin\$(AssemblyName)\$(Configuration)\DiffEngine.dll" PackagePath="dotFiles" Pack="true" Visible="false" />
     <Content Include="bin\$(AssemblyName)\$(Configuration)\Verify.ExceptionParsing.dll" PackagePath="dotFiles" Pack="true" Visible="false" />
     <Content Include="bin\$(AssemblyName)\$(Configuration)\EmptyFiles.dll" PackagePath="dotFiles" Pack="true" Visible="false" />
-    <Content Include="bin\$(AssemblyName)\$(Configuration)\EmptyFiles\**\*" PackagePath="dotFiles\EmptyFiles" Pack="true" Visible="false" />
     <!-- TODO: add additional assemblies -->
   </ItemGroup>
 

--- a/src/dotnet/ReSharperPlugin.Verify/VerifyCompareAction.cs
+++ b/src/dotnet/ReSharperPlugin.Verify/VerifyCompareAction.cs
@@ -47,7 +47,7 @@ public class VerifyCompareAction :
                     continue;
                 }
 
-                if (EmptyFiles.FileExtensions.IsText(file.Received))
+                if (EmptyFiles.FileExtensions.IsTextFile(file.Received))
                 {
                     if (!File.Exists(file.Verified))
                     {

--- a/src/dotnet/ReSharperPlugin.Verify/VerifyOpenAction.cs
+++ b/src/dotnet/ReSharperPlugin.Verify/VerifyOpenAction.cs
@@ -42,7 +42,7 @@ public class VerifyOpenAction :
 
         foreach (var file in files)
         {
-            editorManager.OpenFileAsync(file, OpenFileOptions.DefaultActivate);
+            _ = editorManager.OpenFileAsync(file, OpenFileOptions.DefaultActivate);
         }
 
         bool ShouldOpenFiles()


### PR DESCRIPTION
DiffEngine 17.0.1 -> 19.3.3, EmptyFiles 8.17.1 -> 8.18.2, Verify.ExceptionParsing 31.27.0 -> 31.28.0, all latest stable and all still covering net472. `dependencies.json` had drifted behind the pins it documents - DiffEngine at 11.3.0, EmptyFiles at 4.4.0 - so it comes back in line.

The EmptyFiles bump is what kills the `EmptyFiles\**\*` content glob. Up to 8.17.x the package copied its 50 templates to `$(TargetDir)EmptyFiles` via a build target, and since gradle builds and packs in two separate MSBuild invocations, the pack invocation re-evaluated the project with those files already on disk. The glob was live. 8.18.2 embeds the templates and ships `lib` only, so nothing lands in the output directory, and packing before and after the line gives the same ten entries at the same sizes - on 8.17.1 it was fifty-nine.

Also clears the two code warnings the build was carrying. `FileExtensions.IsText` has been obsolete since 8.17.x and `file.Received` is a path, so `IsTextFile` is the right half of the split. `OpenFileAsync` returns a `Task<ITextControl?>` that the void `IExecutableAction.Execute` has nowhere to await, so the result is now explicitly discarded.